### PR TITLE
Modify asset flags

### DIFF
--- a/libraries/chain/asset_evaluator.cpp
+++ b/libraries/chain/asset_evaluator.cpp
@@ -41,6 +41,9 @@ bool _is_authorized_asset( const database& d, const account_object& acct, const 
 
 void asset_create_evaluator::do_apply( const asset_create_operation& op )
 { try {
+   if( db().has_hardfork( BTCM_HARDFORK_0_1 ) )
+      FC_ASSERT( !op.common_options.issuer_permissions && !op.common_options.flags, "No flags allowed!" );
+
    auto& asset_indx = db().get_index_type<asset_index>().indices().get<by_symbol>();
    auto asset_symbol_itr = asset_indx.find( op.symbol );
    FC_ASSERT( asset_symbol_itr == asset_indx.end(), "Asset with symbol ${s} already exist", ("s",op.symbol) );
@@ -116,9 +119,6 @@ void asset_update_evaluator::do_apply(const asset_update_operation& o)
    FC_ASSERT( asset_symbol_itr != asset_indx.end(), "Asset with symbol id ${d} does not exist exist", ("d",o.asset_to_update) );
 
    auto a = *asset_symbol_itr;
-   auto a_copy = a; 
-   a_copy.options = o.new_options;
-   a_copy.validate();
 
    if( o.new_issuer )
    {

--- a/libraries/chain/asset_evaluator.cpp
+++ b/libraries/chain/asset_evaluator.cpp
@@ -65,10 +65,17 @@ void asset_create_evaluator::do_apply( const asset_create_operation& op )
    {
       auto prefix = op.symbol.substr( 0, dotpos );
       auto asset_symbol_itr = asset_indx.find( prefix );
-      FC_ASSERT( asset_symbol_itr != asset_indx.end(), "Asset ${s} may only be created by issuer of ${p}, but ${p} has not been registered",
+      FC_ASSERT( asset_symbol_itr != asset_indx.end(), "Sub-asset ${s} may only be created if ${p} exists",
                  ("s",op.symbol)("p",prefix) );
-      FC_ASSERT( asset_symbol_itr->issuer == issuer.id, "Asset ${s} may only be created by issuer of ${p}",
-                 ("s",op.symbol)("p",prefix) );
+      if( asset_symbol_itr->options.flags & hashtag )
+      {
+	 account_id_type holder = db().get_nft_holder( *asset_symbol_itr );
+         FC_ASSERT( holder == issuer.id, "Asset ${s} may only be created by holder of ${p}",
+                    ("s",op.symbol)("p",prefix) );
+      }
+      else
+         FC_ASSERT( asset_symbol_itr->issuer == issuer.id, "Asset ${s} may only be created by issuer of ${p}",
+                    ("s",op.symbol)("p",prefix) );
    }
 
    if( op.common_options.flags & hashtag ) // move to validate() after hf

--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -2479,8 +2479,8 @@ void database::init_genesis( const genesis_state_type& initial_allocation )
                string issuer_name = asset.issuer_name;
                a.issuer = get_account_id(issuer_name);
                a.options.max_supply = asset.max_supply;
-               a.options.flags = disable_confidential;
-               a.options.issuer_permissions = UIA_ASSET_ISSUER_PERMISSION_MASK;
+               a.options.flags = 0;
+               a.options.issuer_permissions = 0;
          });
       }
       //initial balances
@@ -3493,6 +3493,10 @@ void database::apply_hardfork( uint32_t hardfork )
 
    switch( hardfork )
    {
+      case BTCM_HARDFORK_0_1:
+         for( const auto& asset : get_index_type<asset_index>().indices() )
+            modify( asset, [] (asset_object& a) { a.options.flags = a.options.issuer_permissions = 0; } );
+         break;
       default:
          break;
    }

--- a/libraries/chain/database.cpp
+++ b/libraries/chain/database.cpp
@@ -3411,6 +3411,15 @@ asset database::get_balance( const account_object& a, asset_id_type symbol )cons
    return itr->get_balance();
 }
 
+account_id_type database::get_nft_holder( const asset_object& asset )const
+{
+   FC_ASSERT( asset.precision == 0 && asset.options.max_supply == 1, "Not an NFT asset" );
+   const auto& index = get_index_type<account_balance_index>().indices().get<by_asset_balance>();
+   const auto itr = index.find( asset.id );
+   FC_ASSERT( itr != index.end() && itr->asset_type == asset.id, "Balance not found!" );
+   return itr->owner;
+}
+
 void database::init_hardforks()
 {
    _hardfork_times[ 0 ] = fc::time_point_sec( BTCM_GENESIS_TIME );

--- a/libraries/chain/include/btcm/chain/asset_object.hpp
+++ b/libraries/chain/include/btcm/chain/asset_object.hpp
@@ -45,17 +45,6 @@ namespace btcm { namespace chain {
          static const uint8_t type_id  = impl_asset_object_type;
          share_type current_supply;
 
-         /// This function does not check if any registered asset has this symbol or not; it simply checks whether the
-         /// symbol would be valid.
-         /// @return true if symbol is a valid ticker symbol; false otherwise.
-         //static bool is_valid_symbol( const string& symbol );
-
-         /// @return true if this asset charges a fee for the issuer on market operations; false otherwise
-         bool charges_market_fees()const { return options.flags & charge_market_fee; }
-         /// @return true if this asset may only be transferred to/from the issuer or market orders
-         bool is_transfer_restricted()const { return options.flags & transfer_restricted; }
-         bool allow_confidential()const { return !(options.flags & asset_issuer_permission_flags::disable_confidential); }
-
          /// Helper function to get an asset object with the given amount in this asset's type
          asset amount(share_type a)const { return asset(a, id); }
          /// Convert a string amount (i.e. "123.45") to an asset object with this asset's type
@@ -84,18 +73,7 @@ namespace btcm { namespace chain {
          asset_options options;
 
 
-         /// Current supply, fee pool, and collected fees are stored in a separate object as they change frequently.
-
          asset_id_type get_id()const { return id; }
-
-
-         void validate()const
-         {
-            // UIAs may not be prediction markets, have force settlement, or global settlements
-            FC_ASSERT(!(options.flags & disable_force_settle || options.flags & global_settle));
-            FC_ASSERT(!(options.issuer_permissions & disable_force_settle || options.issuer_permissions & global_settle));
-         }
-
    };
 
    struct by_symbol;

--- a/libraries/chain/include/btcm/chain/database.hpp
+++ b/libraries/chain/include/btcm/chain/database.hpp
@@ -275,6 +275,8 @@ namespace btcm { namespace chain {
          asset       get_balance( const account_object& a, asset_id_type symbol )const;
          asset       get_balance( const string& aname, asset_id_type symbol )const { return get_balance( get_account(aname), symbol ); }
 
+         account_id_type get_nft_holder( const asset_object& asset )const;
+
          uint64_t    get_scoring(const account_object& ao ) const;
          uint64_t    get_scoring(const content_object& co ) const;
          void recalculate_score(const account_object& ao );

--- a/libraries/chain/include/btcm/chain/protocol/asset_ops.hpp
+++ b/libraries/chain/include/btcm/chain/protocol/asset_ops.hpp
@@ -33,10 +33,10 @@ namespace btcm { namespace chain {
 
    enum asset_issuer_permission_flags
    {
-      dummy    = 0x01, /**< unused */
+      hashtag = 0x01, /**< allows token holder to create sub-asset and enforces max supply = 1 and precision = 0 */
    };
 
-   const static uint32_t ALLOWED_ASSET_PERMISSIONS = 0;
+   const static uint32_t ALLOWED_ASSET_PERMISSIONS = 1;
    const static uint32_t DEFAULT_UIA_PERMISSIONS = 0;
 
    /**
@@ -86,10 +86,6 @@ namespace btcm { namespace chain {
       uint8_t                 precision = BTCM_ASSET_PRECISION;
 
       /// Options common to all assets.
-      ///
-      /// @note common_options.core_exchange_rate technically needs to store the asset ID of this new asset. Since this
-      /// ID is not known at the time this operation is created, create this price as though the new asset has instance
-      /// ID 1, and the chain will overwrite it with the new asset's ID.
       asset_options              common_options;
       extensions_type extensions;
 

--- a/libraries/chain/include/btcm/chain/protocol/asset_ops.hpp
+++ b/libraries/chain/include/btcm/chain/protocol/asset_ops.hpp
@@ -33,17 +33,11 @@ namespace btcm { namespace chain {
 
    enum asset_issuer_permission_flags
    {
-      charge_market_fee    = 0x01, /**< an issuer-specified percentage of all market trades in this asset is paid to the issuer */
-      white_list           = 0x02, /**< accounts must be whitelisted in order to hold this asset */
-      override_authority   = 0x04, /**< issuer may transfer asset back to himself */
-      transfer_restricted  = 0x08, /**< require the issuer to be one party to every transfer */
-      disable_force_settle = 0x10, /**< disable force settling */
-      global_settle        = 0x20, /**< allow the bitasset issuer to force a global settling -- this may be set in permissions, but not flags */
-      disable_confidential = 0x40, /**< allow the asset to be used with confidential transactions */
+      dummy    = 0x01, /**< unused */
    };
 
-   const static uint32_t ASSET_ISSUER_PERMISSION_MASK = charge_market_fee|white_list|override_authority|transfer_restricted|disable_force_settle|global_settle|disable_confidential;
-   const static uint32_t UIA_ASSET_ISSUER_PERMISSION_MASK = charge_market_fee|transfer_restricted|disable_confidential;
+   const static uint32_t ALLOWED_ASSET_PERMISSIONS = 0;
+   const static uint32_t DEFAULT_UIA_PERMISSIONS = 0;
 
    /**
     * @brief The asset_options struct contains options available on all assets in the network
@@ -62,7 +56,7 @@ namespace btcm { namespace chain {
       share_type max_market_fee = BTCM_MAX_SHARE_SUPPLY;
 
       /// The flags which the issuer has permission to update. See @ref asset_issuer_permission_flags
-      uint16_t issuer_permissions = UIA_ASSET_ISSUER_PERMISSION_MASK;
+      uint16_t issuer_permissions = DEFAULT_UIA_PERMISSIONS;
       /// The currently active flags on this permission. See @ref asset_issuer_permission_flags
       uint16_t flags = 0;
 

--- a/libraries/chain/include/btcm/chain/protocol/asset_ops.hpp
+++ b/libraries/chain/include/btcm/chain/protocol/asset_ops.hpp
@@ -34,9 +34,10 @@ namespace btcm { namespace chain {
    enum asset_issuer_permission_flags
    {
       hashtag = 0x01, /**< allows token holder to create sub-asset and enforces max supply = 1 and precision = 0 */
+      allow_subasset_creation = 0x02, /**< allows anyone to create subassets for twice the normal fee, requires hashtag */
    };
 
-   const static uint32_t ALLOWED_ASSET_PERMISSIONS = 1;
+   const static uint32_t ALLOWED_ASSET_PERMISSIONS = 3;
    const static uint32_t DEFAULT_UIA_PERMISSIONS = 0;
 
    /**

--- a/libraries/chain/proposal_evaluator.cpp
+++ b/libraries/chain/proposal_evaluator.cpp
@@ -51,9 +51,22 @@ namespace impl {
                           "Disallowed permissions detected!" );
                FC_ASSERT( !(op.common_options.flags & ~ALLOWED_ASSET_PERMISSIONS),
                           "Disallowed flags detected!" );
-               if( op.common_options.flags & hashtag )
+               if( (op.common_options.flags & hashtag) || (op.common_options.issuer_permissions & hashtag) )
+               {
                   FC_ASSERT( op.precision == 0 && op.common_options.max_supply == 1,
                              "hashtag flag requires precision 0 and max_supply 1" );
+                  FC_ASSERT( (op.common_options.flags & hashtag) || !(op.common_options.flags & allow_subasset_creation),
+                             "allow_subasset_creation flag requires hashtag" );
+                  FC_ASSERT( (op.common_options.issuer_permissions & hashtag)
+                             || !(op.common_options.issuer_permissions & allow_subasset_creation),
+                             "allow_subasset_creation permission requires hashtag" );
+               }
+               else
+               {
+                  FC_ASSERT( !(op.common_options.flags & allow_subasset_creation)
+                             && !(op.common_options.issuer_permissions & allow_subasset_creation),
+                             "allow_subasset_creation flag/permission requires hashtag" );
+               }
                return;
             }
          }

--- a/libraries/chain/proposal_evaluator.cpp
+++ b/libraries/chain/proposal_evaluator.cpp
@@ -46,7 +46,16 @@ namespace impl {
 
          void operator()( const btcm::chain::asset_create_operation& op )const {
             if( _db.has_hardfork( BTCM_HARDFORK_0_1 ) )
-               FC_ASSERT( !op.common_options.issuer_permissions && !op.common_options.flags, "No flags allowed!" );
+            {
+               FC_ASSERT( !(op.common_options.issuer_permissions & ~ALLOWED_ASSET_PERMISSIONS),
+                          "Disallowed permissions detected!" );
+               FC_ASSERT( !(op.common_options.flags & ~ALLOWED_ASSET_PERMISSIONS),
+                          "Disallowed flags detected!" );
+               if( op.common_options.flags & hashtag )
+                  FC_ASSERT( op.precision == 0 && op.common_options.max_supply == 1,
+                             "hashtag flag requires precision 0 and max_supply 1" );
+               return;
+            }
          }
 
          void operator()( const btcm::chain::proposal_create_operation& v )const {

--- a/libraries/chain/proposal_evaluator.cpp
+++ b/libraries/chain/proposal_evaluator.cpp
@@ -71,6 +71,10 @@ namespace impl {
             }
          }
 
+         void operator()( const btcm::chain::asset_update_operation& v )const {
+            FC_ASSERT( _db.has_hardfork( BTCM_HARDFORK_0_1 ), "asset_update not allowed yet!" );
+         }
+
          void operator()( const btcm::chain::proposal_create_operation& v )const {
             bool proposal_update_seen = false;
             for (const op_wrapper &op : v.proposed_ops)

--- a/libraries/chain/proposal_evaluator.cpp
+++ b/libraries/chain/proposal_evaluator.cpp
@@ -44,6 +44,11 @@ namespace impl {
          template<typename T>
          void operator()( const T& v )const { /* do nothing by default */ }
 
+         void operator()( const btcm::chain::asset_create_operation& op )const {
+            if( _db.has_hardfork( BTCM_HARDFORK_0_1 ) )
+               FC_ASSERT( !op.common_options.issuer_permissions && !op.common_options.flags, "No flags allowed!" );
+         }
+
          void operator()( const btcm::chain::proposal_create_operation& v )const {
             bool proposal_update_seen = false;
             for (const op_wrapper &op : v.proposed_ops)

--- a/libraries/chain/protocol/asset_ops.cpp
+++ b/libraries/chain/protocol/asset_ops.cpp
@@ -104,7 +104,7 @@ void asset_options::validate()const
    FC_ASSERT( market_fee_percent <= BTCM_100_PERCENT );
    FC_ASSERT( max_market_fee >= 0 && max_market_fee <= BTCM_MAX_SHARE_SUPPLY );
    // There must be no high bits in permissions whose meaning is not known.
-   FC_ASSERT( !(issuer_permissions & ~ ASSET_ISSUER_PERMISSION_MASK) );
+   FC_ASSERT( !(issuer_permissions & ~0x7f) );
 
 }
 

--- a/libraries/chain/protocol/asset_ops.cpp
+++ b/libraries/chain/protocol/asset_ops.cpp
@@ -79,7 +79,7 @@ void  asset_create_operation::validate()const
 
 void asset_update_operation::validate()const
 {
-   FC_ASSERT(!"disabled");
+   FC_ASSERT(!new_issuer);
    if( new_issuer )
       FC_ASSERT(issuer != *new_issuer);
    new_options.validate();

--- a/libraries/wallet/include/btcm/wallet/wallet.hpp
+++ b/libraries/wallet/include/btcm/wallet/wallet.hpp
@@ -889,7 +889,7 @@ class wallet_api
        * @param broadcast Broadcast the transaction?
        */
       annotated_signed_transaction create_asset(string issuer, string asset_name, string description,
-                                                uint8_t precision, uint64_t max_supply, bool broadcast);
+                                                uint8_t precision, uint64_t max_supply, uint16_t flags, bool broadcast);
       
       /**
        * Issue asset to an account

--- a/libraries/wallet/include/btcm/wallet/wallet.hpp
+++ b/libraries/wallet/include/btcm/wallet/wallet.hpp
@@ -886,6 +886,7 @@ class wallet_api
        * @param description Description
        * @param precision how many decimals the asset should support
        * @param max_supply Maximum supply (in satoshis!)
+       * @param flags a bitset of flags (1 = hashtag, 2 = allow_subasset_creation)
        * @param broadcast Broadcast the transaction?
        */
       annotated_signed_transaction create_asset(string issuer, string asset_name, string description,
@@ -915,9 +916,11 @@ class wallet_api
        * @param description Description
        * @param max_supply Maximum supply
        * @param new_issuer Transfer asset to new issuer
+       * @param flags a bitset of flags (1 = hashtag, 2 = allow_subasset_creation)
        * @param broadcast Broadcast the transaction?
        */      
-      annotated_signed_transaction update_asset(string asset_name, string description, uint64_t max_supply, string new_issuer, bool broadcast);
+      annotated_signed_transaction update_asset(string asset_name, string description, uint64_t max_supply,
+                                                string new_issuer, uint16_t flags, bool broadcast);
 
       /**
        * Get content submitted by given account

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -1085,7 +1085,7 @@ public:
    }
 
    annotated_signed_transaction create_asset(string issuer, string asset_name, string description,
-                                             uint8_t precision, uint64_t max_supply, bool broadcast)
+                                             uint8_t precision, uint64_t max_supply, uint16_t flags, bool broadcast)
    {
       try {
          account_object issuer_account = get_account( issuer );
@@ -1101,8 +1101,8 @@ public:
          create_op.precision = precision;
          create_op.common_options.description = std::move(description);
          create_op.common_options.max_supply=max_supply;
-         create_op.common_options.issuer_permissions=DEFAULT_UIA_PERMISSIONS;
-         create_op.common_options.flags=DEFAULT_UIA_PERMISSIONS;
+         create_op.common_options.issuer_permissions = flags;
+         create_op.common_options.flags = flags;
          signed_transaction tx;
          tx.operations.push_back( create_op );
          tx.validate();
@@ -2653,9 +2653,10 @@ uint64_t wallet_api::get_content_scoring( string content )
    return my->_remote_db->get_content_scoring(content);
 }
 
-annotated_signed_transaction wallet_api::create_asset(string issuer, string asset_name, string description, uint8_t precision, uint64_t max_supply, bool broadcast)
+annotated_signed_transaction wallet_api::create_asset(string issuer, string asset_name, string description,
+                                                      uint8_t precision, uint64_t max_supply, uint16_t flags, bool broadcast)
 {
-   return my->create_asset(issuer, asset_name, description, precision, max_supply, broadcast);
+   return my->create_asset(issuer, asset_name, description, precision, max_supply, flags, broadcast);
 }
 
 annotated_signed_transaction wallet_api::issue_asset(string asset_name, string to_account, string amount, bool broadcast)

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -1101,7 +1101,7 @@ public:
          create_op.precision = precision;
          create_op.common_options.description = std::move(description);
          create_op.common_options.max_supply=max_supply;
-         create_op.common_options.issuer_permissions = flags;
+         create_op.common_options.issuer_permissions = flags | ((flags & hashtag) ? allow_subasset_creation : 0);
          create_op.common_options.flags = flags;
          signed_transaction tx;
          tx.operations.push_back( create_op );

--- a/libraries/wallet/wallet.cpp
+++ b/libraries/wallet/wallet.cpp
@@ -1101,7 +1101,8 @@ public:
          create_op.precision = precision;
          create_op.common_options.description = std::move(description);
          create_op.common_options.max_supply=max_supply;
-         create_op.common_options.flags=override_authority|disable_confidential;
+         create_op.common_options.issuer_permissions=DEFAULT_UIA_PERMISSIONS;
+         create_op.common_options.flags=DEFAULT_UIA_PERMISSIONS;
          signed_transaction tx;
          tx.operations.push_back( create_op );
          tx.validate();
@@ -1119,15 +1120,14 @@ public:
          
          asset_update_operation update_op;
          update_op.issuer = get_account_from_id(asset_to_update->issuer)->name;
-         update_op.new_options.flags=override_authority|disable_confidential;
+         update_op.new_options = asset_to_update->options;
          update_op.asset_to_update = asset_to_update->id;
          if(new_issuer.length()>0){
             get_account( new_issuer );
             update_op.new_issuer = new_issuer;
          }
-         update_op.new_options.max_supply=max_supply;
          if(description.length()>0){
-            update_op.new_options.description=description;
+            update_op.new_options.description = description;
          }
 
          signed_transaction tx;

--- a/tests/tests/asset_tests.cpp
+++ b/tests/tests/asset_tests.cpp
@@ -137,11 +137,13 @@ BOOST_FIXTURE_TEST_CASE( flags_test, database_fixture )
     trx.set_expiration( db.head_block_time() + BTCM_MAX_TIME_UNTIL_EXPIRATION );
 
     {
+	// convert some for asset_create fees
         convert_operation cop;
         cop.owner = "federation";
         cop.amount = asset(50 * BTCM_ASSET_CREATION_FEE, BTCM_SYMBOL);
         trx.operations.emplace_back(std::move(cop));
 
+	// create an asset with classic flags
         asset_create_operation aco;
         aco.fee = asset(BTCM_ASSET_CREATION_FEE, XUSD_SYMBOL);
         aco.issuer = "federation";
@@ -162,11 +164,13 @@ BOOST_FIXTURE_TEST_CASE( flags_test, database_fixture )
 
     generate_block();
 
+    // verify classic flags have been unset when applying hf
     const auto& bts = db.get_asset( "BTS" );
     BOOST_CHECK_EQUAL( 0u, bts.options.flags );
     BOOST_CHECK_EQUAL( 0u, bts.options.issuer_permissions );
 
     {
+	// verify classic flags are no longer allowed
         asset_create_operation aco;
         aco.fee = asset(BTCM_ASSET_CREATION_FEE, XUSD_SYMBOL);
         aco.issuer = "federation";
@@ -180,6 +184,7 @@ BOOST_FIXTURE_TEST_CASE( flags_test, database_fixture )
         BOOST_CHECK_THROW( PUSH_TX(db, trx), fc::assert_exception );
         trx.clear();
 
+	// ...but it works without any flags
         aco.common_options.issuer_permissions = 0;
         aco.common_options.flags = 0;
         trx.operations.emplace_back(std::move(aco));
@@ -462,6 +467,7 @@ BOOST_FIXTURE_TEST_CASE( create_hashtag_flag, database_fixture )
    BOOST_REQUIRE( !db.has_hardfork( BTCM_HARDFORK_0_1 ) );
 
    {
+      // convert some for asset_create fees
       convert_operation cop;
       cop.owner = "federation";
       cop.amount = asset(50 * BTCM_ASSET_CREATION_FEE, BTCM_SYMBOL);
@@ -470,6 +476,7 @@ BOOST_FIXTURE_TEST_CASE( create_hashtag_flag, database_fixture )
       PUSH_TX(db, trx);
       trx.clear();
 
+      // create a pre-hardfork asset with hashtag flag
       asset_create_operation aco;
       aco.fee = asset(BTCM_ASSET_CREATION_FEE, XUSD_SYMBOL);
       aco.issuer = "federation";
@@ -490,11 +497,13 @@ BOOST_FIXTURE_TEST_CASE( create_hashtag_flag, database_fixture )
 
    generate_block();
 
+   // verify flag has been cleared in hf
    const auto& pre = db.get_asset( "PREHF" );
    BOOST_CHECK_EQUAL( 0u, pre.options.flags );
    BOOST_CHECK_EQUAL( 0u, pre.options.issuer_permissions );
 
    {
+      // hashtag create fails with wrong precision / supply
       asset_create_operation aco;
       aco.fee = asset(BTCM_ASSET_CREATION_FEE, XUSD_SYMBOL);
       aco.issuer = "federation";
@@ -509,6 +518,7 @@ BOOST_FIXTURE_TEST_CASE( create_hashtag_flag, database_fixture )
       BOOST_CHECK_THROW( PUSH_TX(db, trx), fc::assert_exception );
       trx.clear();
 
+      // hashtag create proposal fails with wrong precision / supply
       proposal_create_operation pop;
       pop.expiration_time = db.head_block_time() + fc::days(1);
       pop.proposed_ops.emplace_back( aco );
@@ -516,6 +526,7 @@ BOOST_FIXTURE_TEST_CASE( create_hashtag_flag, database_fixture )
       BOOST_CHECK_THROW( PUSH_TX(db, trx), fc::assert_exception );
       trx.clear();
 
+      // hashtag create fails with wrong supply
       aco.precision = 0;
       aco.common_options.max_supply = 100000;
       trx.operations.emplace_back(aco);
@@ -523,12 +534,14 @@ BOOST_FIXTURE_TEST_CASE( create_hashtag_flag, database_fixture )
       BOOST_CHECK_THROW( PUSH_TX(db, trx), fc::assert_exception );
       trx.clear();
 
+      // hashtag create proposal fails with wrong supply
       pop.proposed_ops.clear();
       pop.proposed_ops.emplace_back( aco );
       trx.operations.emplace_back(pop);
       BOOST_CHECK_THROW( PUSH_TX(db, trx), fc::assert_exception );
       trx.clear();
 
+      // hashtag create fails with wrong precision
       aco.precision = 5;
       aco.common_options.max_supply = 1;
       trx.operations.emplace_back(aco);
@@ -536,12 +549,14 @@ BOOST_FIXTURE_TEST_CASE( create_hashtag_flag, database_fixture )
       BOOST_CHECK_THROW( PUSH_TX(db, trx), fc::assert_exception );
       trx.clear();
 
+      // hashtag create proposal fails with wrong precision
       pop.proposed_ops.clear();
       pop.proposed_ops.emplace_back( aco );
       trx.operations.emplace_back(pop);
       BOOST_CHECK_THROW( PUSH_TX(db, trx), fc::assert_exception );
       trx.clear();
 
+      // hashtag create works
       aco.precision = 0;
       aco.common_options.max_supply = 1;
       trx.operations.emplace_back(aco);
@@ -549,12 +564,14 @@ BOOST_FIXTURE_TEST_CASE( create_hashtag_flag, database_fixture )
       PUSH_TX(db, trx);
       trx.clear();
 
+      // hashtag create proposal works
       pop.proposed_ops.clear();
       pop.proposed_ops.emplace_back( aco );
       trx.operations.emplace_back(pop);
       PUSH_TX(db, trx);
       trx.clear();
 
+      // create without hashtag works with other precision/supply
       aco.symbol = "SOME";
       aco.precision = 5;
       aco.common_options.max_supply = 100000;
@@ -581,9 +598,12 @@ BOOST_AUTO_TEST_CASE( create_subasset )
    trx.set_expiration( db.head_block_time() + BTCM_MAX_TIME_UNTIL_EXPIRATION );
 
    {
+      // convert some for create fees
       convert_operation cop;
       cop.owner = "federation";
       cop.amount = asset(5 * BTCM_ASSET_CREATION_FEE, BTCM_SYMBOL);
+
+      // create with hashtag flag
       trx.operations.emplace_back(std::move(cop));
       asset_create_operation aco;
       aco.fee = asset(BTCM_ASSET_CREATION_FEE, XUSD_SYMBOL);
@@ -595,6 +615,8 @@ BOOST_AUTO_TEST_CASE( create_subasset )
       aco.common_options.flags = hashtag;
       aco.common_options.description = "IOU for BitShares core token";
       trx.operations.emplace_back(aco);
+
+      // create without hashtag flag
       aco.symbol = "BTC";
       aco.precision = 8;
       aco.common_options.max_supply = 2100000000000;
@@ -606,6 +628,7 @@ BOOST_AUTO_TEST_CASE( create_subasset )
       PUSH_TX(db, trx);
       trx.clear();
 
+      // issue hashtag supply to federation
       asset_issue_operation aio;
       aio.issuer = "federation";
       aio.issue_to_account = "federation";
@@ -615,6 +638,7 @@ BOOST_AUTO_TEST_CASE( create_subasset )
       PUSH_TX(db, trx);
       trx.clear();
 
+      // convert some for create fees
       cop.owner = "alice";
       cop.amount = asset(2 * BTCM_ASSET_CREATION_FEE, BTCM_SYMBOL);
       trx.operations.emplace_back(cop);
@@ -622,6 +646,7 @@ BOOST_AUTO_TEST_CASE( create_subasset )
       PUSH_TX(db, trx);
       trx.clear();
 
+      // convert some for create fees
       cop.owner = "bob";
       trx.operations.emplace_back(std::move(cop));
       sign(trx, bob_private_key);
@@ -634,6 +659,7 @@ BOOST_AUTO_TEST_CASE( create_subasset )
    const auto& fashion = db.get_asset( "FASHION" );
 
    {
+      // alice can't create subasset of FASHION
       asset_create_operation aco;
       aco.fee = asset(BTCM_ASSET_CREATION_FEE, XUSD_SYMBOL);
       aco.issuer = "alice";
@@ -644,12 +670,14 @@ BOOST_AUTO_TEST_CASE( create_subasset )
       BOOST_CHECK_THROW( PUSH_TX(db, trx), fc::assert_exception );
       trx.clear();
 
+      // federation can create subasset of FASHION
       aco.issuer = "federation";
       trx.operations.emplace_back(aco);
       sign(trx, federation_private_key);
       PUSH_TX(db, trx);
       trx.clear();
 
+      // federation transfers FASHION to alice
       transfer_operation top;
       top.from = "federation";
       top.to = "alice";
@@ -659,6 +687,7 @@ BOOST_AUTO_TEST_CASE( create_subasset )
       PUSH_TX(db, trx);
       trx.clear();
 
+      // now federation can't create subasset of FASHION
       aco.symbol = "FASHION.HAT";
       aco.common_options.description = "Another test sub";
       trx.operations.emplace_back(aco);
@@ -666,8 +695,11 @@ BOOST_AUTO_TEST_CASE( create_subasset )
       BOOST_CHECK_THROW( PUSH_TX(db, trx), fc::assert_exception );
       trx.clear();
 
+      // ...but alice can
       aco.issuer = "alice";
       trx.operations.emplace_back(aco);
+
+      // alice transfers FASHION to bob
       top.from = "alice";
       top.to = "bob";
       trx.operations.emplace_back(top);
@@ -675,6 +707,7 @@ BOOST_AUTO_TEST_CASE( create_subasset )
       PUSH_TX(db, trx);
       trx.clear();
 
+      // now alice can't create subasset anymore
       aco.symbol = "FASHION.SHOE";
       aco.common_options.description = "Yet another test sub";
       trx.operations.emplace_back(aco);
@@ -682,12 +715,14 @@ BOOST_AUTO_TEST_CASE( create_subasset )
       BOOST_CHECK_THROW( PUSH_TX(db, trx), fc::assert_exception );
       trx.clear();
 
+      // ...but bob can
       aco.issuer = "bob";
       trx.operations.emplace_back(aco);
       sign(trx, bob_private_key);
       PUSH_TX(db, trx);
       trx.clear();
 
+      // bob can't create subasset of BTC
       aco.symbol = "BTC.SHOE";
       aco.common_options.description = "BTC test sub";
       trx.operations.emplace_back(aco);
@@ -695,9 +730,224 @@ BOOST_AUTO_TEST_CASE( create_subasset )
       BOOST_CHECK_THROW( PUSH_TX(db, trx), fc::assert_exception );
       trx.clear();
 
+      // ...but federation can
       aco.issuer = "federation";
       trx.operations.emplace_back(aco);
       sign(trx, federation_private_key);
+      PUSH_TX(db, trx);
+      trx.clear();
+   }
+
+} FC_LOG_AND_RETHROW() }
+
+BOOST_FIXTURE_TEST_CASE( allow_subasset_flag, database_fixture )
+{ try {
+   initialize_clean( 0 );
+
+   ACTORS( (alice)(bob)(federation) );
+   fund( "alice", 50000000 );
+   fund( "bob", 50000000 );
+   fund( "federation", 5000000000 );
+
+   set_price_feed( price( ASSET( "1.000 2.28.0" ), ASSET( "1.000 2.28.2" ) ) );
+
+   trx.clear();
+   trx.set_expiration( db.head_block_time() + BTCM_MAX_TIME_UNTIL_EXPIRATION );
+
+   {
+      // convert some for asset create fee
+      convert_operation cop;
+      cop.owner = "federation";
+      cop.amount = asset(10 * BTCM_ASSET_CREATION_FEE, BTCM_SYMBOL);
+      trx.operations.emplace_back(std::move(cop));
+
+      // create PREHF asset with hashtag flag
+      asset_create_operation aco;
+      aco.fee = asset(BTCM_ASSET_CREATION_FEE, XUSD_SYMBOL);
+      aco.issuer = "federation";
+      aco.symbol = "PREHF";
+      aco.precision = 0;
+      aco.common_options.max_supply = 1;
+      aco.common_options.issuer_permissions = hashtag | allow_subasset_creation;
+      aco.common_options.flags = hashtag;
+      aco.common_options.description = "Pre-HF test token";
+      trx.operations.emplace_back(std::move(aco));
+      sign(trx, federation_private_key);
+      PUSH_TX(db, trx);
+      trx.clear();
+
+      const auto& prehf = db.get_asset( "PREHF" );
+
+      // issue PREHF to alice
+      asset_issue_operation aio;
+      aio.issuer = "federation";
+      aio.issue_to_account = "alice";
+      aio.asset_to_issue = prehf.amount( 1 );
+      trx.operations.emplace_back(std::move(aio));
+      sign(trx, federation_private_key);
+      PUSH_TX(db, trx);
+      trx.clear();
+
+      // federation can't update
+      asset_update_operation auo;
+      auo.asset_to_update = prehf.id;
+      auo.issuer = "federation";
+      auo.new_options.flags = hashtag | allow_subasset_creation;
+      trx.operations.emplace_back(auo);
+      sign(trx, federation_private_key);
+      BOOST_CHECK_THROW( PUSH_TX(db, trx), fc::assert_exception );
+      trx.clear();
+
+      // alice can't update
+      auo.issuer = "alice";
+      trx.operations.emplace_back(auo);
+      sign(trx, alice_private_key);
+      BOOST_CHECK_THROW( PUSH_TX(db, trx), fc::assert_exception );
+      trx.clear();
+
+      // alice can't update through proposal
+      proposal_create_operation pop;
+      pop.expiration_time = db.head_block_time() + fc::days(1);
+      pop.proposed_ops.emplace_back( auo );
+      BOOST_CHECK_THROW( PUSH_TX(db, trx), fc::assert_exception );
+      trx.clear();
+   }
+
+   generate_block();
+
+   db.set_hardfork( BTCM_HARDFORK_0_1, true );
+
+   generate_block();
+
+   {
+      // create FASHION with hashtag flag and allow_subasset permission
+      asset_create_operation aco;
+      aco.fee = asset(BTCM_ASSET_CREATION_FEE, XUSD_SYMBOL);
+      aco.issuer = "federation";
+      aco.symbol = "FASHION";
+      aco.precision = 0;
+      aco.common_options.max_supply = 1;
+      aco.common_options.issuer_permissions = hashtag | allow_subasset_creation;
+      aco.common_options.flags = hashtag;
+      aco.common_options.description = "Hashtag test token";
+      trx.operations.emplace_back(aco);
+
+      // create HASH with hashtag flag but without allow_subasset permission
+      aco.symbol = "HASH";
+      aco.common_options.description = "Hashtag test token without subasset";
+      aco.common_options.issuer_permissions = hashtag;
+      trx.operations.emplace_back(std::move(aco));
+      sign(trx, federation_private_key);
+      PUSH_TX(db, trx);
+      trx.clear();
+   }
+
+   generate_block();
+
+   const auto& fashion = db.get_asset( "FASHION" );
+   const auto& hash = db.get_asset( "HASH" );
+   const auto& pre = db.get_asset( "PREHF" );
+
+   {
+      // asset_update proposal can now be created
+      asset_update_operation auo;
+      auo.asset_to_update = pre.id;
+      auo.issuer = "federation";
+      auo.new_options.flags = hashtag | allow_subasset_creation;
+      proposal_create_operation pop;
+      pop.expiration_time = db.head_block_time() + fc::days(1);
+      pop.proposed_ops.emplace_back( auo );
+      trx.operations.emplace_back(pop);
+      PUSH_TX(db, trx);
+      trx.clear();
+
+      // convert some for asset_create fees
+      convert_operation cop;
+      cop.owner = "alice";
+      cop.amount = asset(3 * BTCM_ASSET_CREATION_FEE, BTCM_SYMBOL);
+      trx.operations.emplace_back(cop);
+      sign(trx, alice_private_key);
+      PUSH_TX(db, trx);
+      trx.clear();
+
+      // convert some for asset_create fees
+      cop.owner = "bob";
+      trx.operations.emplace_back(cop);
+      sign(trx, bob_private_key);
+      PUSH_TX(db, trx);
+      trx.clear();
+
+      // issue FASHION and HASH to alice
+      asset_issue_operation aio;
+      aio.issuer = "federation";
+      aio.issue_to_account = "alice";
+      aio.asset_to_issue = asset( 1, db.get_asset( "FASHION" ).id );
+      trx.operations.emplace_back(aio);
+      aio.asset_to_issue = asset( 1, db.get_asset( "HASH" ).id );
+      trx.operations.emplace_back(aio);
+      sign(trx, federation_private_key);
+      PUSH_TX(db, trx);
+      trx.clear();
+   }
+
+   generate_block();
+
+   {
+      // bob can't create any subassets
+      asset_create_operation aco;
+      aco.fee = asset(BTCM_ASSET_CREATION_FEE, XUSD_SYMBOL);
+      aco.issuer = "bob";
+      aco.symbol = "FASHION.SHIRT";
+      aco.common_options.description = "Test sub";
+      trx.operations.emplace_back(aco);
+      sign(trx, bob_private_key);
+      BOOST_CHECK_THROW( PUSH_TX(db, trx), fc::assert_exception );
+      trx.clear();
+
+      aco.symbol = "HASH.SHIRT";
+      trx.operations.emplace_back(aco);
+      sign(trx, bob_private_key);
+      BOOST_CHECK_THROW( PUSH_TX(db, trx), fc::assert_exception );
+      trx.clear();
+
+      aco.symbol = "PREHF.SHIRT";
+      trx.operations.emplace_back(aco);
+      sign(trx, bob_private_key);
+      BOOST_CHECK_THROW( PUSH_TX(db, trx), fc::assert_exception );
+      trx.clear();
+
+      // alice can't update HASH for allow_subasset_create
+      asset_update_operation auo;
+      auo.issuer = "alice";
+      auo.asset_to_update = hash.id;
+      auo.new_options = hash.options;
+      auo.new_options.flags = hashtag | allow_subasset_creation;
+      trx.operations.emplace_back(auo);
+      sign(trx, alice_private_key);
+      BOOST_CHECK_THROW( PUSH_TX(db, trx), fc::assert_exception );
+      trx.clear();
+
+      // alice can update FASHION for allow_subasset_create
+      auo.asset_to_update = fashion.id;
+      auo.new_options = fashion.options;
+      auo.new_options.flags = hashtag | allow_subasset_creation;
+      trx.operations.emplace_back(auo);
+      sign(trx, alice_private_key);
+      PUSH_TX(db, trx);
+      trx.clear();
+
+      // bob still can't create subasset with normal fee
+      aco.symbol = "FASHION.SHIRT";
+      trx.operations.emplace_back(aco);
+      sign(trx, bob_private_key);
+      BOOST_CHECK_THROW( PUSH_TX(db, trx), fc::assert_exception );
+      trx.clear();
+
+      // ...but with twice the normal fee it works
+      aco.fee = asset(2*BTCM_ASSET_CREATION_FEE, XUSD_SYMBOL);
+      aco.symbol = "FASHION.SHIRT";
+      trx.operations.emplace_back(aco);
+      sign(trx, bob_private_key);
       PUSH_TX(db, trx);
       trx.clear();
    }


### PR DESCRIPTION
* disables old (unused) flags
* adds `hashtag` flag to indicate that token holder can create subassets
* adds `allow_subasset_creation` flag to indicate that anyone can create subassets